### PR TITLE
Establish an internal network, wire up access to tapp network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,15 @@ services:
       SECRET_KEY_BASE: ${SECRET_KEY_BASE}
     volumes:
       - .:/srv/app
+    networks:
+      - internal
+      - tapp_external
     ports:
       - "5000:3000"
     links:
       - postgres
+    external_links:
+      - tapp_rails-app:tapp
     command: >
       ./bin/rails-server-entrypoint -b 0.0.0.0 -p 3000 -P /dev/null
 
@@ -25,12 +30,22 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
       - /var/lib/postgresql/data
+    networks:
+      - internal
 
   webpack-dev-server:
     build: .
     volumes:
       - .:/srv/app
+    networks:
+      - internal
     ports:
       - "7070:8080"
     command: >
       ./bin/webpack-dev-server-entrypoint --host 0.0.0.0
+
+networks:
+  internal: # aka cp_internal
+    driver: bridge
+  tapp_external:
+    external: true


### PR DESCRIPTION
You'll need [this PR](https://github.com/uoft-tapp/tapp/pull/110) to be applied on tapp for this to make sense.

This PR makes CP project join TAPP's external network and link in `tapp_rails-app` to be available as `tapp` host to the rails-app service.

From cp, you can test access to tapp rails app as follows:
1. Launch tapp project with `docker-compose up`. TAPP project must be running for CP to be able to access TAPP API.
2. Launch a rails console in cp with `docker-compose run rails-app rails c`.
3. Run the following to query TAPP API: 
    ```
    require "net/http"
    require "uri"

    uri = URI.parse("http://tapp:3000/applicants") # Or any other path

    # Will print response.body
    Net::HTTP.get_print(uri)
    ```