### PR TITLE
Fixes issues in PR#2

### DIFF
--- a/app/controllers/hello_react_controller.rb
+++ b/app/controllers/hello_react_controller.rb
@@ -8,7 +8,7 @@ class HelloReactController < ApplicationController
       filename: "#{Rails.root}/tmp/contracts/1342088432-CSC104H1F-contract.pdf",
       email: "mingtsengeh@gmail.com"
       }
-    test = CpMailer.contract_email(@user).deliver_now!
+    CpMailer.contract_email(@user).deliver_now!
     render json: @contractor.get_parsed
   end
 end

--- a/app/controllers/hello_react_controller.rb
+++ b/app/controllers/hello_react_controller.rb
@@ -6,9 +6,9 @@ class HelloReactController < ApplicationController
       name: "Landy Simpson",
       course: "CSC104H1F",
       filename: "#{Rails.root}/tmp/contracts/1342088432-CSC104H1F-contract.pdf",
-      email: "landi.simpson@live.com"
+      email: "mingtsengeh@gmail.com"
       }
-    CpMailer.contract_email(@user.as_json).deliver_now!
+    test = CpMailer.contract_email(@user).deliver_now!
     render json: @contractor.get_parsed
   end
 end

--- a/app/controllers/hello_react_controller.rb
+++ b/app/controllers/hello_react_controller.rb
@@ -8,7 +8,7 @@ class HelloReactController < ApplicationController
       filename: "#{Rails.root}/tmp/contracts/1342088432-CSC104H1F-contract.pdf",
       email: "mingtsengeh@gmail.com"
       }
-    CpMailer.contract_email(@user).deliver_now!
+    CpMailer.contract_email(@user).deliver_now
     render json: @contractor.get_parsed
   end
 end

--- a/app/mailers/cp_mailer.rb
+++ b/app/mailers/cp_mailer.rb
@@ -5,9 +5,9 @@ class CpMailer < ApplicationMailer
 
   def contract_email(user)
     @user = user
-    Rails.logger.debug "HERE #{@user["filename"]}"
+    Rails.logger.debug "HERE #{@user[:filename]}"
     @url = "http://google.com"
-    attachments[@user["filename"]] = File.read(@user["filename"])
-    mail(to: @user["email"], subject: "Testing Email")
+    attachments[@user[:filename]] = File.read(@user[:filename])
+    mail(to: @user[:email], subject: "Testing Email")
   end
 end

--- a/app/mailers/cp_mailer.rb
+++ b/app/mailers/cp_mailer.rb
@@ -1,5 +1,5 @@
 class CpMailer < ApplicationMailer
-  default from: 'cookies@mailinator.com'
+  default from: ENV['EMAIL_USER']
 
   layout "mailer"
 

--- a/app/views/cp_mailer/contract_email.html.erb
+++ b/app/views/cp_mailer/contract_email.html.erb
@@ -4,7 +4,7 @@
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
   </head>
   <body>
-    <h1>Congradulations, <%= @user[:name] %></h1>
+    <h1>Congratulations, <%= @user[:name] %></h1>
     <p>
       You have successfully been choosen to TA <%= @user[:course] %>
     </p>

--- a/app/views/cp_mailer/contract_email.html.erb
+++ b/app/views/cp_mailer/contract_email.html.erb
@@ -4,9 +4,9 @@
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
   </head>
   <body>
-    <h1>Congradulations, <%= @user["name"] %></h1>
+    <h1>Congradulations, <%= @user[:name] %></h1>
     <p>
-      You have successfully been choosen to TA <%= @user["course"] %>
+      You have successfully been choosen to TA <%= @user[:course] %>
     </p>
     <p>
       Click the url below accept this offer: <%= @url %>.

--- a/app/views/cp_mailer/contract_email.text.erb
+++ b/app/views/cp_mailer/contract_email.text.erb
@@ -1,7 +1,7 @@
-Congradulations, <%= @user["name"] %>
+Congradulations, <%= @user[:name] %>
 ====================================
 
-You have successfully been choosen to TA <%= @user["course"] %>
+You have successfully been choosen to TA <%= @user[:course] %>
 
 Click the url below accept this offer: <%= @url %>.
 Your contract has been attached to this email!

--- a/app/views/cp_mailer/contract_email.text.erb
+++ b/app/views/cp_mailer/contract_email.text.erb
@@ -1,4 +1,4 @@
-Congradulations, <%= @user[:name] %>
+Congratulations, <%= @user[:name] %>
 ====================================
 
 You have successfully been choosen to TA <%= @user[:course] %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,15 +28,15 @@ Rails.application.configure do
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = true
-
+  config.action_mailer.default_url_options = { :host => 'localhost:5000' }
   config.action_mailer.perform_caching = true
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-     address: 'smtp.live.com',
-     port: 465,
-     domain: 'hotmail.com',
-     user_name: ENV['hotmail_user'],
-     password: ENV['hotmail_pass'],
+     address: 'smtp.gmail.com',
+     port: 587,
+     domain: 'gmail.com',
+     user_name: ENV['EMAIL_USER'],
+     password: ENV['EMAIL_PASSWORD'],
      authentication: 'plain',
      enable_starttls_auto: true
  }

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -32,14 +32,14 @@ Rails.application.configure do
   config.action_mailer.perform_caching = true
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-     address: 'smtp.gmail.com',
+     address: "smtp.#{ENV['EMAIL_TYPE']}.com",
      port: 587,
      domain: 'gmail.com',
      user_name: ENV['EMAIL_USER'],
      password: ENV['EMAIL_PASSWORD'],
-     authentication: 'plain',
+     authentication: ENV['EMAIL_AUTH'],
      enable_starttls_auto: true
- }
+  }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,10 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       SECRET_KEY_BASE: ${SECRET_KEY_BASE}
+      EMAIL_TYPE: ${EMAIL_TYPE}
       EMAIL_USER: ${EMAIL_USER}
       EMAIL_PASSWORD: ${EMAIL_PASSWORD}
+      EMAIL_AUTH: ${EMAIL_AUTH}
     volumes:
       - .:/srv/app
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       SECRET_KEY_BASE: ${SECRET_KEY_BASE}
+      EMAIL_USER: ${EMAIL_USER}
+      EMAIL_PASSWORD: ${EMAIL_PASSWORD}
     volumes:
       - .:/srv/app
     ports:


### PR DESCRIPTION
- This is based off @simpslandyy's PR #2
- This PR target PR #2 for merging, **not** master
- **Please await @simpslandyy's approval before trying to merge this.**
- This fixed the `Connection Refused` issue as well as the `Open Timeout`
- This currently only works for both Gmail and Outlook
- Steps to get this working:
  - run `cp dev.env.default .env`
  - set the variables `EMAIL_TYPE`, `EMAIL_USER`, `EMAIL_PASSWORD`, and `EMAIL_AUTH` in `.env`  from the pinned info on Slack
    - if you want to use your own email, follow the instruction near the bottom of the description to make sure your email is authenticated to send messages using the CP  app
  - modify line of `hello_react_controller` and change my email to yours
  - open up the email you wrote in `hello_react_controller`
  - run `docker-compose up` as usual
  - go to `localhost:5000/hello_react`
  - if it renders a JSON of 2 different offers, then you should get your email within the next minute

Cause of the errors in PR#2:
- the environmental variables `ENV['hotmail_user']` and `ENV['hotmail_pass']` were set to blank because they were never defined. And since they were meant to be the sender. PR #2 was basically trying to send emails anonymously.

Setting up your own account as the sender (Extra):
- Gmail:
  - sign into your Gmail account
  - go to [link 1](https://myaccount.google.com/lesssecureapps) and [link 2](https://accounts.google.com/DisplayUnlockCaptcha)
    - you have to turn off the security and display unlock captcha
- Outlook:
  - download the Outlook (2016) Desktop app onto your PC
  - Start up Outlook, go to `File` in the top menu
  - Go to `Info` on the side bar, and click `Account Settings` on the right panel
  - Click on the drop down that appears after you click on the button
  - In the pop-up window, stay on the `Email` tab
  - Click `New...` and choose `Manual setup or additional server types`
  - On the next screen, choose `POP or IMAP`
  - This next screen requires information you can only get from your email account, so you have to log into the Outlook email you want to configure as host
  - In your online email account, click on the gear button to the top right and choose `Options`
  - Then, on the sidebar, go to `Mail > Accounts > POP and IMAP`
  - The right panel that appears after you clicked on the right link on the sidebar will give you the necessary information to fill in the form in your Outlook app setup
  - For the following fields, enter your Outlook email:
    - `Your Name`
    - `Email Address`
    - `User Name`
  - Enter the password to this email in `Password`
  - Choose the `Account Type` to be IMAP
  - set the `Incoming mail server` as the `server name` under `IMAP setting` on in your email account
  - set the `Outgoing mail server (SMTP)` as the `server name` under `SMTP setting` on in your email account
  - Then click on the button `More Settings...` on the bottom right corner of the dialog 
  - A new pop-up should appear
  - Go to the `Outgoing Server` tab, click on the checkbox `My outgoing server (SMTP) requires authentication`
  - Choose the radio button `Use the same settings as my incoming mail server`
  - Then, move onto the next tab `Advanced`
  - Choose the type of encryption for both the incoming/outgoing server as `TLS`
  - Click `ok` on the bottom of this dialog
  - Click `Next >` on the remaining dialog, and once the test that Outlook run both pass, and you're done!
 

