### PR TITLE
indicate contract as unsigned in pdf

### DIFF
--- a/app/services/contract_generator.rb
+++ b/app/services/contract_generator.rb
@@ -255,6 +255,8 @@ class ContractGenerator
     set_text(get_grids(x, y+0.2, 3, 0.6), get_style(SMALL_LEFT_ALIGN, "Applicant Signature".upcase))
     if offer[:signature]
       set_text(get_grids(x, y-0.05, 3, 0.6), get_style(INITIAL, offer[:signature]))
+    else
+      set_text(get_grids(x, y-0.2, 3, 0.6), get_style(REGULAR_LEFT_ALIGN, "<i>Not Yet Electronically Signed</i>"))
     end
   end
 


### PR DESCRIPTION
- as described in title
- below is an example of the difference between a signed and unsigned PDF:
  - Signed:
![screenshot from 2017-08-24 13-06-56](https://user-images.githubusercontent.com/22383586/29678628-4d92ab3a-88cd-11e7-8f65-5ee523cfc05e.png)
  - Unsigned:
![screenshot from 2017-08-24 13-07-06](https://user-images.githubusercontent.com/22383586/29678646-61424aaa-88cd-11e7-9d24-22cb3c6221c9.png)
