### PR TITLE
create scheduled email for offers accepted alert

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,5 +52,7 @@ group :development do
   gem 'guard-rspec', require: false
 end
 
+gem 'rufus-scheduler', require: false
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,8 @@ GEM
     concurrent-ruby (1.0.5)
     diff-lcs (1.3)
     erubi (1.6.0)
+    et-orbi (1.0.5)
+      tzinfo
     execjs (2.7.0)
     ffi (1.9.18)
     formatador (0.2.5)
@@ -170,6 +172,8 @@ GEM
       rspec-support (~> 3.6.0)
     rspec-support (3.6.0)
     ruby_dep (1.5.0)
+    rufus-scheduler (3.4.2)
+      et-orbi (~> 1.0)
     sass (3.4.24)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
@@ -228,6 +232,7 @@ DEPENDENCIES
   puma (~> 3.7)
   rails (~> 5.1.1)
   rspec-rails (~> 3.5)
+  rufus-scheduler
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -202,7 +202,7 @@ class OffersController < ApplicationController
 
   def update_status(offer, status)
     if status[:action]=="accept"
-      offer.update_attributes!({status: status[:name], signature: status[:signature]})
+      offer.update_attributes!({status: status[:name], signature: status[:signature], accept_datetime: DateTime.now})
     else
       offer.update_attributes!({status: status[:name]})
     end

--- a/app/mailers/cp_mailer.rb
+++ b/app/mailers/cp_mailer.rb
@@ -18,6 +18,12 @@ class CpMailer < ApplicationMailer
     mail(to: email, subject: "Reminder for TA Position: #{@contract[:position]}")
   end
 
+  def status_email(num_accepted)
+    @num_accepted = num_accepted
+    email = get_email(ENV["HR_ADMIN_EMAIL"])
+    mail(to: email, subject: "CP Alert: New Offers Accepted")
+  end
+
   private
   def get_nag_suffix(nag_count)
     case nag_count

--- a/app/mailers/cp_mailer.rb
+++ b/app/mailers/cp_mailer.rb
@@ -18,8 +18,9 @@ class CpMailer < ApplicationMailer
     mail(to: email, subject: "Reminder for TA Position: #{@contract[:position]}")
   end
 
-  def status_email(num_accepted)
+  def status_email(num_accepted, time_elapsed)
     @num_accepted = num_accepted
+    @time_elapsed = time_elapsed
     email = get_email(ENV["HR_ADMIN_EMAIL"])
     mail(to: email, subject: "CP Alert: New Offers Accepted")
   end

--- a/app/views/cp_mailer/status_email.html.erb
+++ b/app/views/cp_mailer/status_email.html.erb
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <p>Dear <%= ENV["HR_ADMIN_NAME"] %>,</p>
+    <p>There was a total of <%= @num_accepted %> offers that were accepted in the last 24 hours.</p>
+    <p>Have a great day!</p>
+  </body>
+</html>

--- a/app/views/cp_mailer/status_email.html.erb
+++ b/app/views/cp_mailer/status_email.html.erb
@@ -5,7 +5,7 @@
   </head>
   <body>
     <p>Dear <%= ENV["HR_ADMIN_NAME"] %>,</p>
-    <p>There was a total of <%= @num_accepted %> offers that were accepted in the last 24 hours.</p>
+    <p>There was a total of <%= @num_accepted %> offers that were accepted in the last <%= @time_elapsed %>.</p>
     <p>Have a great day!</p>
   </body>
 </html>

--- a/app/views/cp_mailer/status_email.text.erb
+++ b/app/views/cp_mailer/status_email.text.erb
@@ -1,0 +1,6 @@
+Dear <%= ENV["HR_ADMIN_NAME"] %>,
+====================================
+
+There was a total of <%= @num_accepted %> offers that were accepted in the last 24 hours.
+
+Have a great day!

--- a/app/views/cp_mailer/status_email.text.erb
+++ b/app/views/cp_mailer/status_email.text.erb
@@ -1,6 +1,6 @@
 Dear <%= ENV["HR_ADMIN_NAME"] %>,
 ====================================
 
-There was a total of <%= @num_accepted %> offers that were accepted in the last 24 hours.
+There was a total of <%= @num_accepted %> offers that were accepted in the last <%= @time_elapsed %>.
 
 Have a great day!

--- a/config/initializers/scheduler.rb
+++ b/config/initializers/scheduler.rb
@@ -1,0 +1,22 @@
+require 'rufus-scheduler'
+
+s = Rufus::Scheduler.singleton
+
+s.cron('0 7 * * *') do
+  date = DateTime.now
+  today = date.strftime("%A")
+  if today != "Sunday" && today != "Saturday"
+    yesterday = date.days_ago(1)
+    num_offers = 0
+    Offer.all.each do |offer|
+      if offer[:accept_datetime]
+        if offer[:accept_datetime]>=yesterday && offer[:status]=="Accepted"
+          num_offers+=1
+        end
+      end
+    end
+    if num_offers> 0
+      CpMailer.status_email(num_offers).deliver_now
+    end
+  end
+end

--- a/config/initializers/scheduler.rb
+++ b/config/initializers/scheduler.rb
@@ -6,7 +6,13 @@ s.cron('0 7 * * *') do
   date = DateTime.now
   today = date.strftime("%A")
   if today != "Sunday" && today != "Saturday"
-    yesterday = date.days_ago(1)
+    if today == "Monday"
+      yesterday = date.days_ago(3)
+      time_elapsed = "3 days"
+    else
+      yesterday = date.days_ago(1)
+      time_elapsed = "24 hours"
+    end
     num_offers = 0
     Offer.all.each do |offer|
       if offer[:accept_datetime]
@@ -16,7 +22,7 @@ s.cron('0 7 * * *') do
       end
     end
     if num_offers> 0
-      CpMailer.status_email(num_offers).deliver_now
+      CpMailer.status_email(num_offers, time_elapsed).deliver_now
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,6 @@ Rails.application.routes.draw do
     status of another student.
   '''
   get "pb/:mangled" => "app#student_view"
-  get "pb/:mangled/pdf" => "offers#get_contract_pdf"
+  get "pb/:mangled/pdf" => "offers#get_contract_mangled"
   post "pb/:mangled/:status" => "offers#set_status_mangled"
 end

--- a/db/migrate/20170718181301_create_offers.rb
+++ b/db/migrate/20170718181301_create_offers.rb
@@ -14,6 +14,7 @@ class CreateOffers < ActiveRecord::Migration[5.1]
       t.datetime :send_date, null: true
       t.integer :nag_count, default: 0
       t.string :signature
+      t.datetime :accept_datetime, default: nil
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 20170718181301) do
     t.datetime "send_date"
     t.integer "nag_count", default: 0
     t.string "signature"
+    t.datetime "accept_datetime"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["applicant_id"], name: "index_offers_on_applicant_id"

--- a/dev.env.default
+++ b/dev.env.default
@@ -25,3 +25,5 @@ EMAIL_USER=ta-hr-admin@cs.toronto.edu
 TA_COORD=Karen Reid
 CUPE_SITE=http://google.com
 RECIPIENT=test.smtpcp@gmail.com
+HR_ADMIN_EMAIL=lisab@cs.toronto.edu
+HR_ADMIN_NAME=Lisa De Caro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       TA_COORD: ${TA_COORD}
       CUPE_SITE: ${CUPE_SITE}
       RECIPIENT: ${RECIPIENT}
+      HR_ADMIN_EMAIL: ${HR_ADMIN_EMAIL}
+      HR_ADMIN_NAME: ${HR_ADMIN_NAME}
     networks:
       - default
       - tapp_frontend


### PR DESCRIPTION
- added `HR_ADMIN_EMAIL` and `HR_ADMIN_NAME` to `.env`
- create email template for status email update
- installed gem `rufus-scheduler`
- fixed mangled route typo in `routes.rb`
- set email to send every weekday when there's an offer accepted within 24 hours; shows last three days for Monday.

To test this the following commands in order:
- `cp dev.env.default .env` 
- `docker-compose build rails-app`
- `docker-compose run rails-app rake db:drop db:create db:migrate`
- `docker-compose up`
- go to the default Gmail Pinned in Slack to check for emails
- This actually sends an email only once a day so it should be left running for a while